### PR TITLE
Fixed fruit styles

### DIFF
--- a/Chaua-Educa-main/script.js
+++ b/Chaua-Educa-main/script.js
@@ -213,14 +213,14 @@ function play() {
             let randomFruitImage = fruitImages[Math.floor(Math.random() * fruitImages.length)];
     
             let fruit_sprite1 = document.createElement('img');
-            fruit_sprite1.className = 'fruit';
+            fruit_sprite1.classList.add("fruit")
             fruit_sprite1.src = randomFruitImage;
             if (randomFruitImage === 'images/goiaba-verde.png') {
-                fruit_sprite1.classList.add('fruit-goiaba-verde');
+                fruit_sprite1.classList.add('goiaba-verde');
             } else if (randomFruitImage === 'images/semente-de-girassol.png') {
-                fruit_sprite1.classList.add('fruit-semente-de-girassol');
+                fruit_sprite1.classList.add('semente-de-girassol');
             } else if (randomFruitImage === 'images/manga-verde.png') {
-                fruit_sprite1.classList.add('fruit-manga-verde');
+                fruit_sprite1.classList.add('manga-verde');
             }
     
             fruit_sprite1.style.left = fruit_x + 'px';

--- a/Chaua-Educa-main/style.css
+++ b/Chaua-Educa-main/style.css
@@ -34,76 +34,38 @@
   
 }
 
-.fruit-goiaba-verde {
+.fruit {
 	position: fixed;
 	top: 40vh;
 	left: 100vw;
 	height: 6vh;
 	width: 9vw;
+	background-size: contain;
+	border: none;
+	transform: scaleX(-1); /* Inverte horizontalmente para que o tronco fique na direção correta */
+}
+.goiaba-verde {
     background: url('images/goiaba-verde.png') no-repeat center center;
-	background-size: contain;
-	border: none;
-	transform: scaleX(-1); /* Inverte horizontalmente para que o tronco fique na direção correta */
 }
 
-.fruit-banana-verde {
-	position: fixed;
-	top: 40vh;
-	left: 100vw;
-	height: 6vh;
-	width: 9vw;
+.banana-verde {
     background: url('images/banana-verde.png') no-repeat center center;
-	background-size: contain;
-	border: none;
-	transform: scaleX(-1); /* Inverte horizontalmente para que o tronco fique na direção correta */
 }
 
-.fruit-coquinho-verde {
-	position: fixed;
-	top: 40vh;
-	left: 100vw;
-	height: 6vh;
-	width: 9vw;
+.coquinho-verde {
     background: url('images/coquinho-verde.png') no-repeat center center;
-	background-size: contain;
-	border: none;
-	transform: scaleX(-1); /* Inverte horizontalmente para que o tronco fique na direção correta */
 }
 
-.fruit-mamao-verde {
-	position: fixed;
-	top: 40vh;
-	left: 100vw;
-	height: 6vh;
-	width: 9vw;
+.mamao-verde {
     background: url('images/mamao-verde.png') no-repeat center center;
-	background-size: contain;
-	border: none;
-	transform: scaleX(-1); /* Inverte horizontalmente para que o tronco fique na direção correta */
 }
 
-.fruit-semente-de-girassol {
-	position: fixed;
-	top: 40vh;
-	left: 100vw;
-	height: 6vh;
-	width: 9vw;
+.semente-de-girassol {
     background: url('images/semente-de-girassol.png') no-repeat center center;
-	background-size: contain;
-	border: none;
-	transform: scaleX(-1); /* Inverte horizontalmente para que o tronco fique na direção correta */
 }
 
-.fruit-manga-verde {
-	position: fixed;
-	top: 40vh;
-	left: 100vw;
-	height: 6vh;
-	width: 9vw;
+.manga-verde {
     background: url('images/manga-verde.png') no-repeat center center;
-	background-size: contain;
-	border: none;
-	transform: scaleX(-1); /* Inverte horizontalmente para que o tronco fique na direção correta */
 }
 
 .tree-inverted {


### PR DESCRIPTION
Apply CSS cascading to fruit CSS classes. We use a general `fruit` class for all common fruit styles, and then custom style for the background of the fruits. In the JavaScript code, we also ensure that a general `fruit` className is added for fruit sprite, along with the specific fruit style that define the image background.